### PR TITLE
feat: update docker to allow access to nats through lanchonete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+# Docker Compose configuration file
+
+# Define the services that make up the app
+services:
+  # MongoDB service
+  mongodb:
+    image: mongo:8.0.0-rc4
+    container_name: mongodb_container
+    networks:
+      - lanchonete_lanchonete
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongodb_data_container:/data/db
+    ports:
+      - 27017:27017
+
+  # Lanchonete Pagamento service
+  lanchonete-pagamento:
+    build: .
+    container_name: lanchonete-pagamento
+    depends_on:
+      - mongodb
+    volumes:
+      - m2-repo:/usr/share/maven
+    ports:
+      - "8081:8081"
+    command: ["prod"]
+    networks:
+      - lanchonete_lanchonete
+    environment:
+      # NATS configuration
+      NATS_APP_NAME: pagamento
+      NATS_NEW_ORDERS: pagamento.novo-pedido
+      NATS_PUBLISH_STATUS: status
+      NATS_PUSLISH_NEW_PAYMENT: novo-pagamento
+      NATS_URL: nats://nats:4222
+
+      # MongoDB configuration
+      MONGO_URI: mongodb://root:example@mongodb:27017/admin
+      MONGO_DB: fiap-lanchonete-pagamento
+      MONGO_COLLECTION: pagamento
+
+# Define the volumes used by the services
+volumes:
+  m2-repo:
+  mongodb_data_container:
+
+networks:
+  lanchonete_lanchonete:
+    external: true

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -16,7 +16,7 @@
  [:mba-fiap.adapter.nats/nats :nats/nats]
  {:url #env NATS_URL
   :app-name #or [#env NATS_APP_NAME "pagamento"]
-  :subjects-handlers {#or [#env NATS_NEW_ORDERS "lanchonete.novo-pedido"] #ig/ref :handler/novos-pedidos}}
+  :subjects-handlers {#or [#env NATS_NEW_ORDERS "pagamento.novo-pedido"] #ig/ref :handler/novos-pedidos}}
 
  [:mba-fiap.usecase.processar-pagamento/novos-pedidos :handler/novos-pedidos]
  {:repository/pagamento #ig/ref :repository/pagamento
@@ -28,7 +28,7 @@
  {:env #profile {:default :dev
                  :test :test
                  :prod :prod}
-  :port #long #profile {:default #or [#env HTTP_PORT 8080]}
+  :port #long #profile {:default #or [#env HTTP_PORT 8081]}
   :join? #profile {:default true
                    :test false
                    :dev false}

--- a/test/mba_fiap/pagamento_test.clj
+++ b/test/mba_fiap/pagamento_test.clj
@@ -45,7 +45,7 @@
 
 (deftest test-main-startup
   (testing "main startup ok"
-    (let [{:keys [body status]} (hc/get "http://localhost:8080/healthcheck")]
+    (let [{:keys [body status]} (hc/get "http://localhost:8081/healthcheck")]
       (is (= 200 status)))))
 
 


### PR DESCRIPTION
Adicionado docker-compose para construção do serviço e ajuste para poder consumir do lanchonete-core as informações do nats através do network. 

